### PR TITLE
Fix build error caused by setuptools version

### DIFF
--- a/docker/flexos.dockerfile
+++ b/docker/flexos.dockerfile
@@ -28,6 +28,7 @@ RUN apt install -y build-essential libncurses-dev python3 expect-dev moreutils \
 	qemu-utils curl gawk git procps socat uuid-runtime python3-pip libsqlite3-dev \
 	bc libiscsi-dev librbd1 libnfs-dev libgfapi0 libffi-dev libiperf-dev net-tools \
 	bridge-utils iperf dnsmasq ninja-build gdb cscope
+RUN pip3 install -U setuptools==41.0
 
 ##############
 # Toolchain


### PR DESCRIPTION
Addresses a build error caused by an incorrect version of setuptools, the error and its fix and documented here: https://github.com/project-flexos/asplos22-ae/issues/4